### PR TITLE
Use PyPI trusted publishing

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,37 +1,33 @@
-# This workflow will upload a Python Package using Twine when a release is created
-# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
-
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
-name: Upload Python Package
+name: Publish Python Package
 
 on:
   push:
     tags:
       - "*.*.*"
 
-jobs:
-  deploy:
+permissions:
+  contents: read
 
+jobs:
+  publish:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    environment:
+      name: pypi
+      url: https://pypi.org/p/simplesimplestreams
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.9'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install poetry
-        poetry install
-    - name: Build package
-      run: poetry build
-    - name: Publish
-      env:
-        POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_TOKEN }}
-      run: poetry publish
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install Poetry with pipx
+        run: |
+          python -m pip install --user --upgrade pip pipx
+          ~/.local/bin/pipx install poetry
+      - name: Build package
+        run: ~/.local/bin/poetry build
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -22,11 +22,11 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.9"
       - name: Install Poetry with pipx
         run: |
           python -m pip install --user --upgrade pip pipx
-          ~/.local/bin/pipx install poetry
+          ~/.local/bin/pipx install "poetry==1.8.5"
       - name: Build package
         run: ~/.local/bin/poetry build
       - name: Publish to PyPI

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -26,8 +26,8 @@ jobs:
       - name: Install Poetry with pipx
         run: |
           python -m pip install --user --upgrade pip pipx
-          ~/.local/bin/pipx install "poetry==1.8.5"
+          pipx install "poetry==1.8.5"
       - name: Build package
-        run: ~/.local/bin/poetry build
+        run: poetry build
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ Run type check: `poetry run mypy . --strict` \
 Run tests: `poetry run pytest` \
 Format code: `poetry run black .`
 
+## Publishing
+
+PyPI releases are published by `.github/workflows/python-publish.yml` using PyPI trusted publishing.
+After registering this repository, workflow file, and the `pypi` GitHub Actions environment as a trusted publisher on PyPI, push a version tag such as `0.1.2`.
+
 ## License
 
 Apache-2.0


### PR DESCRIPTION
## Summary
- switch PyPI publishing to GitHub OIDC trusted publishing
- modernize the publish workflow actions and Poetry installation path
- document the trusted publisher setup needed on PyPI

## Testing
- poetry run mypy . --strict
- poetry run pytest
- poetry build