### PR TITLE
Use poetry sync in Poetry 2 workflows

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -22,8 +22,8 @@ jobs:
         run: |
           python -m pip install --user --upgrade pip pipx
           pipx install "poetry==2.2.1"
-      - name: Install dependencies
-        run: poetry install
+      - name: Sync dependencies
+        run: poetry sync
       - name: Build docs
         run: poetry run sphinx-build -b html docs docs/_build
       - uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -27,8 +27,8 @@ jobs:
         run: |
           python -m pip install --user --upgrade pip pipx
           pipx install "poetry==2.2.1"
-      - name: Install dependencies
-        run: poetry install
+      - name: Sync dependencies
+        run: poetry sync
       - name: Type check with mypy
         run: poetry run mypy . --strict
       - name: Test with pytest

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ See [API docs](https://otariidae.github.io/simplesimplestreams/) for more infoma
 
 ## Development
 
-Install dependencies with poetry: `poetry install` \
+Sync dependencies with poetry: `poetry sync` \
 Run type check: `poetry run mypy . --strict` \
 Run tests: `poetry run pytest` \
 Format code: `poetry run black .`


### PR DESCRIPTION
## Summary
- switch the CI dependency setup steps from `poetry install` to `poetry sync`
- update the README development command to match Poetry 2 usage

## Testing
- poetry sync
- poetry run mypy . --strict
- poetry run pytest
- poetry run sphinx-build -b html docs docs/_build