### PR TITLE
Modernize HTTP requests

### DIFF
--- a/simplesimplestreams/simplestreams.py
+++ b/simplesimplestreams/simplestreams.py
@@ -4,6 +4,8 @@ import requests
 # port of lxc/lxd/shared/simplesreams.go
 # based on lxd 4.18
 
+DEFAULT_REQUEST_TIMEOUT = 30
+
 
 # https://github.com/lxc/lxd/blob/lxd-4.18/shared/simplestreams/index.go#L11
 class StreamIndex(TypedDict):
@@ -88,16 +90,19 @@ class SimpleStreamsClient:
         # https://github.com/lxc/lxd/blob/lxd-4.18/client/connection.go#L191
         self.url = url.removesuffix("/")
 
+    def _get_json(self, path: str) -> object:
+        response = requests.get(f"{self.url}/{path}", timeout=DEFAULT_REQUEST_TIMEOUT)
+        response.raise_for_status()
+        return response.json()
+
     def get_stream(self) -> Stream:
         # https://github.com/lxc/lxd/blob/lxd-4.18/shared/simplestreams/simplestreams.go#L152
-        response = requests.get(self.url + "/" + "streams/v1/index.json")
-        return cast(Stream, response.json())
+        return cast(Stream, self._get_json("streams/v1/index.json"))
 
     # https://github.com/lxc/lxd/blob/lxd-4.18/shared/simplestreams/simplestreams.go#L175
     # example: path="streams/v1/images.json"
     def get_products(self, path: str) -> Products:
-        response = requests.get(self.url + "/" + path)
-        return cast(Products, response.json())
+        return cast(Products, self._get_json(path))
 
     # https://github.com/lxc/lxd/blob/lxd-4.18/shared/simplestreams/simplestreams.go#L277
     def list_images(self) -> list[Product]:

--- a/tests/test_simplesimplestreams.py
+++ b/tests/test_simplesimplestreams.py
@@ -2,7 +2,10 @@ from importlib import import_module
 import sys
 from pathlib import Path
 
+import pytest
+import requests
 import responses
+from responses import matchers
 from simplesimplestreams import Products, SimpleStreamsClient, Stream, __version__
 
 tomllib = import_module("tomllib" if sys.version_info >= (3, 11) else "tomli")
@@ -73,6 +76,7 @@ def test_get_stream_uses_index_endpoint() -> None:
         "https://example.test/streams/v1/index.json",
         json=SAMPLE_STREAM,
         status=200,
+        match=[matchers.request_kwargs_matcher({"timeout": 30})],
     )
 
     client = SimpleStreamsClient(url="https://example.test/")
@@ -91,11 +95,13 @@ def test_list_images_filters_non_image_entries() -> None:
         "https://example.test/streams/v1/index.json",
         json=SAMPLE_STREAM,
         status=200,
+        match=[matchers.request_kwargs_matcher({"timeout": 30})],
     )
     responses.get(
         "https://example.test/streams/v1/images.json",
         json=SAMPLE_PRODUCTS,
         status=200,
+        match=[matchers.request_kwargs_matcher({"timeout": 30})],
     )
 
     client = SimpleStreamsClient(url="https://example.test")
@@ -110,3 +116,43 @@ def test_list_images_filters_non_image_entries() -> None:
     image = images[0]
     for field in ("aliases", "arch", "release", "release_title"):
         assert isinstance(image[field], str)
+
+
+@responses.activate
+def test_get_products_uses_relative_path_with_timeout() -> None:
+    payload: Products = {
+        "content_id": "images",
+        "datatype": "image-downloads",
+        "format": "products:1.0",
+        "license": None,
+        "products": {},
+        "updated": None,
+    }
+    responses.get(
+        "https://example.test/streams/v1/images.json",
+        json=payload,
+        status=200,
+        match=[matchers.request_kwargs_matcher({"timeout": 30})],
+    )
+
+    client = SimpleStreamsClient(url="https://example.test")
+
+    assert client.get_products("streams/v1/images.json") == payload
+    assert len(responses.calls) == 1
+    assert (
+        responses.calls[0].request.url == "https://example.test/streams/v1/images.json"
+    )
+
+
+@responses.activate
+def test_get_stream_raises_for_http_errors() -> None:
+    responses.get(
+        "https://example.test/streams/v1/index.json",
+        status=503,
+        match=[matchers.request_kwargs_matcher({"timeout": 30})],
+    )
+
+    client = SimpleStreamsClient(url="https://example.test")
+
+    with pytest.raises(requests.HTTPError):
+        client.get_stream()


### PR DESCRIPTION
## Summary
- centralize HTTP JSON fetches behind a helper
- add an explicit request timeout and `raise_for_status()` handling
- cover the request behavior with focused unit tests

## Testing
- poetry run mypy . --strict
- poetry run pytest -q